### PR TITLE
fix: Run default data creation with elevated privileges

### DIFF
--- a/supabase/migrations/0001_initial_schema.sql
+++ b/supabase/migrations/0001_initial_schema.sql
@@ -457,7 +457,7 @@ BEGIN
     ('Stationery', 'Pens, pencils, notebooks, etc.', school_id),
     ('Electronics', 'Computers, projectors, etc.', school_id);
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- Trigger to automatically create default data for new schools
 CREATE OR REPLACE FUNCTION trigger_create_default_school_data()


### PR DESCRIPTION
The `create_default_school_data` function was failing because it was running with the permissions of the user who created the school, and you did not have permissions to insert into the `subjects` table. This change modifies the function to run with `SECURITY DEFINER` to ensure that it has the necessary permissions to insert the default data.